### PR TITLE
MusicVAE removal of unused level (#1677): Fix in layer initialization

### DIFF
--- a/magenta/models/music_vae/lstm_models.py
+++ b/magenta/models/music_vae/lstm_models.py
@@ -903,7 +903,8 @@ class HierarchicalLstmDecoder(base_model.BaseDecoder):
             hparams.dec_rnn_size,
             dropout_keep_prob=hparams.dropout_keep_prob,
             residual=hparams.residual_decoder)
-        for _ in range(len(self._level_lengths))]
+        # Subtract 1 for the core decoder level
+        for _ in range(len(self._level_lengths) - 1)]
 
     with tf.variable_scope('core_decoder', reuse=tf.AUTO_REUSE):
       self._core_decoder.build(hparams, output_depth, is_training)


### PR DESCRIPTION
Simple fix to prevent memory allocation for unused level in the hierarchical decoder of MusicVAE (see issue #1677). The issue can be marked as solved on merge.