### PR TITLE
Modified to ignore vscode settings folder and all sub-files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@
 .cache/
 build/
 *.DS_Store
-.vscode/*
+.vscode
 .idea/


### PR DESCRIPTION
Previously, only files in the vscode folder were being ignored, but it would be more convenient to ignore the vscode folder as well. 

What do you think about this modification?