### PR TITLE
Fix note sequence encoding in MidiPerformanceEncoder

### DIFF
--- a/magenta/models/score2perf/music_encoders.py
+++ b/magenta/models/score2perf/music_encoders.py
@@ -106,6 +106,7 @@ class MidiPerformanceEncoder(object):
     """
     performance = note_seq.Performance(
         note_seq.quantize_note_sequence_absolute(ns, self._steps_per_second),
+        max_shift_steps=self._steps_per_second,
         num_velocity_bins=self._num_velocity_bins)
 
     event_ids = [self._encoding.encode_event(event) + self.num_reserved_ids


### PR DESCRIPTION
### Issue
`Performance` inside `MidiPerformanceEncoder.encode_note_sequence` expects a quantized note sequence with `max_shift_steps=DEFAULT_MAX_SHIFT_STEPS`. 

As a result, encoded time shift events will lie in the range of `(1, max_shift_steps)` and may not be present in `self._ngrams_trie` built from a smaller vocabulary size (e.g. `steps_per_second < DEFAULT_MAX_SHIFT_STEPS`):

https://github.com/magenta/magenta/blob/9cee6cd75a9ac1aabf11ce10f9a8ff7b86fab0b9/magenta/models/score2perf/music_encoders.py#L121-L125

### Fix
Specify the actual maximum number of steps for a single time-shift event to `Performance`.