### PR TITLE
feat: add warm_start_from for onsets and frames model

### DIFF
--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_train.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_train.py
@@ -47,6 +47,10 @@ tf.app.flags.DEFINE_string(
     'model_dir', '~/tmp/onsets_frames',
     'Path where checkpoints and summary events will be located during '
     'training and evaluation.')
+tf.app.flags.DEFINE_string(
+    'warm_start_from', None,
+    'Optional string filepath to a checkpoint,  then all variables are '
+    'warm-started during training')
 tf.app.flags.DEFINE_string('eval_name', None, 'Name for this eval run.')
 tf.app.flags.DEFINE_integer('num_steps', 1000000,
                             'Number of training steps or `None` for infinite.')
@@ -93,7 +97,9 @@ def run(config_map, data_fn, additional_trial_info):
         preprocess_examples=FLAGS.preprocess_examples,
         hparams=hparams,
         keep_checkpoint_max=FLAGS.keep_checkpoint_max,
-        num_steps=FLAGS.num_steps)
+        num_steps=FLAGS.num_steps,
+        warm_start_from=FLAGS.warm_start_from
+    )
   elif FLAGS.mode == 'eval':
     train_util.evaluate(
         model_fn=config.model_fn,

--- a/magenta/models/onsets_frames_transcription/train_util.py
+++ b/magenta/models/onsets_frames_transcription/train_util.py
@@ -119,7 +119,8 @@ def train(master,
           hparams,
           keep_checkpoint_max,
           use_tpu,
-          num_steps=None):
+          num_steps=None,
+          warm_start_from=None):
   """Train loop."""
   estimator = create_estimator(
       model_fn=model_fn,
@@ -128,7 +129,9 @@ def train(master,
       tpu_cluster=tpu_cluster,
       hparams=hparams,
       keep_checkpoint_max=keep_checkpoint_max,
-      use_tpu=use_tpu)
+      use_tpu=use_tpu,
+      warm_start_from=warm_start_from
+  )
 
   if estimator.config.is_chief:
     _trial_summary(


### PR DESCRIPTION
Add capability to pass the `warm_start_from` parameter for training the onset_and_frames model, to load weights from e-gmd or maestro dataset's checkpoints and train more epochs with new dataset.

fixes: #1869