### PR TITLE
Fix scipy version error

### DIFF
--- a/magenta/models/coconet/lib_evaluation.py
+++ b/magenta/models/coconet/lib_evaluation.py
@@ -19,7 +19,7 @@ import time
 from magenta.models.coconet import lib_tfutil
 from magenta.models.coconet import lib_util
 import numpy as np
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 import tensorflow.compat.v1 as tf
 
 


### PR DESCRIPTION
Fixed error that scipy.mics was deprecated.
Replaced scipy.misc to spicy.special