### PR TITLE
Rl tuner compatibility  fix when usinf TF2

### DIFF
--- a/magenta/models/rl_tuner/rl_tuner.py
+++ b/magenta/models/rl_tuner/rl_tuner.py
@@ -182,6 +182,29 @@ class RLTuner(object):
         self.note_rnn_checkpoint_dir = os.getcwd()
         self.note_rnn_checkpoint_file = os.path.join(os.getcwd(),
                                                      'note_rnn.ckpt')
+       
+        
+        vars_to_rename = {
+            "rnn_model/RNN/MultiRNNCell/Cell0/LSTMCell/W_0": "rnn_model/rnn/multi_rnn_cell/cell_0/lstm_cell/kernel",
+            "rnn_model/RNN/MultiRNNCell/Cell0/LSTMCell/B": "rnn_model/rnn/multi_rnn_cell/cell_0/lstm_cell/bias",
+        }
+        new_checkpoint_vars = {}
+        reader = tf.train.NewCheckpointReader(self.note_rnn_checkpoint_file)
+        for old_name in reader.get_variable_to_shape_map():
+          if old_name in vars_to_rename:
+            new_name = vars_to_rename[old_name]
+          else:
+            new_name = old_name
+          new_checkpoint_vars[new_name] = tf.Variable(reader.get_tensor(old_name))
+
+        init = tf.global_variables_initializer()
+        saver = tf.train.Saver(new_checkpoint_vars)
+
+        with tf.Session() as sess:
+                sess.run(init)
+                saver.save(sess, self.note_rnn_checkpoint_file)
+
+        
 
       if self.note_rnn_hparams is None:
         if self.note_rnn_type == 'basic_rnn':

--- a/magenta/models/rl_tuner/rl_tuner.py
+++ b/magenta/models/rl_tuner/rl_tuner.py
@@ -1962,7 +1962,7 @@ class RLTuner(object):
 
     reward_batch = self.output_every_nth
     x = [reward_batch * i for i in np.arange(len(self.eval_avg_reward))]
-    start_index = start_at_epoch / self.output_every_nth
+    start_index = start_at_epoch // self.output_every_nth
     plt.figure()
     plt.plot(x[start_index:], self.eval_avg_reward[start_index:])
     plt.plot(x[start_index:], self.eval_avg_music_theory_reward[start_index:])

--- a/magenta/models/rl_tuner/rl_tuner_train.py
+++ b/magenta/models/rl_tuner/rl_tuner_train.py
@@ -27,6 +27,7 @@ from magenta.models.rl_tuner import rl_tuner_ops
 import matplotlib
 import matplotlib.pyplot as plt  # pylint: disable=unused-import
 import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 # Need to use 'Agg' option for plotting and saving files from command line.
 # Can't use 'Agg' in RL Tuner because it breaks plotting in notebooks.


### PR DESCRIPTION
Hi, there I have been playing around with RLTuner as part of a mentorship I am doing with Jordi Orbay. I added some fixes to make  `rl_tuner_train` run directly as advertised in the README.

- Added code to rename modules in the downloadable reward_rnn checkpoint
-  Added code to solve an issue with plot evaluation.

There are also changes to be done in the example notebook file, but maybe it is cleaner to do it in another PR. What do you think?