### PR TITLE
docs: Fix a few typos

### DIFF
--- a/magenta/interfaces/midi/midi_hub.py
+++ b/magenta/interfaces/midi/midi_hub.py
@@ -724,7 +724,7 @@ class MidiCaptor(threading.Thread):
           None.
 
     Returns:
-      The unqiue name of the callback thread to enable cancellation.
+      The unique name of the callback thread to enable cancellation.
 
     Raises:
       MidiHubError: If neither `signal` nor `period` or both are specified.

--- a/magenta/models/arbitrary_image_stylization/arbitrary_image_stylization_convert_tflite.py
+++ b/magenta/models/arbitrary_image_stylization/arbitrary_image_stylization_convert_tflite.py
@@ -261,7 +261,7 @@ def predict_model_gen(session, style_dataset, sample_count):
   """Create a generator function that emits style images.
 
   Args:
-    session: tf.Session, the session that contains subgraph to load the traning
+    session: tf.Session, the session that contains subgraph to load the training
       dataset
     style_dataset: tf.data.Dataset that contains training style images.
     sample_count: int, number of sample to create.
@@ -291,7 +291,7 @@ def calculate_style_bottleneck(session,
   """Calculate style bottleneck using style predict SavedModel.
 
   Args:
-    session: tf.Session, the session that contains subgraph to load the traning
+    session: tf.Session, the session that contains subgraph to load the training
       dataset.
     predict_saved_model: str, path to the style predict SavedModel.
     style_dataset: tf.data.Dataset that contains training style images.
@@ -338,7 +338,7 @@ def transform_model_gen(session, predict_saved_model, style_dataset,
   """Create a generator function that emits content images & style bottlenecks.
 
   Args:
-    session: tf.Session, the session that contains subgraph to load the traning
+    session: tf.Session, the session that contains subgraph to load the training
       dataset.
     predict_saved_model: str, path to the style predict SavedModel.
     style_dataset: tf.data.Dataset that contains training style images.

--- a/magenta/models/coconet/lib_util.py
+++ b/magenta/models/coconet/lib_util.py
@@ -274,7 +274,7 @@ def batches(*xss, **kwargs):
 
   Yields batches of the form `[xs[indices] for xs in xss]` where at each
   iteration `indices` selects a subset. Each index is only selected once.
-  **kwards could be one of the following:
+  **kwargs could be one of the following:
     size: number of elements per batch
     discard_remainder: if true, discard final short batch
     shuffle: if true, yield examples in randomly determined order

--- a/magenta/models/sketch_rnn/rnn.py
+++ b/magenta/models/sketch_rnn/rnn.py
@@ -18,7 +18,7 @@ import tensorflow.compat.v1 as tf
 
 
 def orthogonal(shape):
-  """Orthogonal initilaizer."""
+  """Orthogonal initializer."""
   flat_shape = (shape[0], np.prod(shape[1:]))
   a = np.random.normal(0.0, 1.0, flat_shape)
   u, _, v = np.linalg.svd(a, full_matrices=False)


### PR DESCRIPTION
There are small typos in:
- magenta/interfaces/midi/midi_hub.py
- magenta/models/arbitrary_image_stylization/arbitrary_image_stylization_convert_tflite.py
- magenta/models/coconet/lib_util.py
- magenta/models/sketch_rnn/rnn.py

Fixes:
- Should read `training` rather than `traning`.
- Should read `unique` rather than `unqiue`.
- Should read `kwargs` rather than `kwards`.
- Should read `initializer` rather than `initilaizer`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md