### PR TITLE
Added timeout on request.get() for ensuring that if a recipient serve…

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -125,7 +125,8 @@ def load_dataset(data_dir, model_params, inference_mode=False):
     if data_dir.startswith('http://') or data_dir.startswith('https://'):
       data_filepath = '/'.join([data_dir, dataset])
       tf.logging.info('Downloading %s', data_filepath)
-      response = requests.get(data_filepath)
+      # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+      response = requests.get(data_filepath, timeout=100)
       data = np.load(six.BytesIO(response.content), encoding='latin1')
     else:
       data_filepath = os.path.join(data_dir, dataset)


### PR DESCRIPTION
We have detected this issue in the `main` branch of `magenta` project on the version with commit hash `c78440`. This is an instance of an api usage issue.

**Fixes for api usage issue:**
In file: `magenta/models/sketch_rnn/sketch_rnn_train.py`, method `load_dataset` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts)our intelligent code repair system **iCR** suggested that a timeout value should be specified.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)