### PR TITLE
[sketch-rnn] - write hparams `model_config.json` as a dict not a list

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -14,7 +14,6 @@
 
 """SketchRNN training."""
 
-import json
 import os
 import time
 import zipfile

--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -448,7 +448,7 @@ def trainer(model_params):
   tf.gfile.MakeDirs(FLAGS.log_root)
   with tf.gfile.Open(
       os.path.join(FLAGS.log_root, 'model_config.json'), 'w') as f:
-    json.dump(list(model_params.values()), f, indent=True)
+    f.write(model_params.to_json(indent=True))
 
   train(sess, model, eval_model, train_set, valid_set, test_set)
 


### PR DESCRIPTION
this fixes what is evidently a long-standing bug in the way hparams were written by this model.

the fix is to use the `to_json` method provided by the `HParams` class itself. 

without this, the hparams are written as a list of the keys; not as a dictionary of key/values ... 😭 