### PR TITLE
Update audio_recorder.py

### DIFF
--- a/magenta/models/onsets_frames_transcription/realtime/audio_recorder.py
+++ b/magenta/models/onsets_frames_transcription/realtime/audio_recorder.py
@@ -43,8 +43,8 @@ except ModuleNotFoundError:
 
 def resample(audio, source_rate, target_rate):
   if librosa:
-    return librosa.core.resample(
-        audio, orig_sr=source_rate, target_sr=target_rate)
+    return (librosa.core.resample(
+        audio.T, orig_sr=source_rate, target_sr=target_rate)).T
   if samplerate:
     ratio = float(target_rate) / source_rate
     return samplerate.resample(audio, ratio, 'sinc_best')


### PR DESCRIPTION
There was following error when adjusting the microphone sampling rate: "ValueError: Input signal length=1 is too small to resample from 48000->16000.0" A similar issue has been raised here: https://github.com/librosa/librosa/issues/915#issuecomment-508760896 
It seems that the audio data needs to be transposed for librosa, but then retransposed for the return value.